### PR TITLE
Resource.Load

### DIFF
--- a/Internals/Attributes/UTStyles.cs
+++ b/Internals/Attributes/UTStyles.cs
@@ -5,11 +5,11 @@ using UnityEngine;
 
 namespace UdonToolkit {
   public class UTStyles {
-    public static Texture2D ComponentBG = (Texture2D) EditorGUIUtility.Load("Assets/UdonToolkit/Internals/Resources/Component BG.png");
-    public static Texture ArrowR = (Texture) EditorGUIUtility.Load("Assets/UdonToolkit/Internals/Resources/Arrow_R.png");
-    public static Texture ArrowL = (Texture) EditorGUIUtility.Load("Assets/UdonToolkit/Internals/Resources/Arrow_L.png");
-    public static Texture Utils = (Texture) EditorGUIUtility.Load("Assets/UdonToolkit/Internals/Resources/Utils.png");
-    public static Texture Undo = (Texture) EditorGUIUtility.Load("Assets/UdonToolkit/Internals/Resources/Undo.png");
+    public static Texture2D ComponentBG = Resources.Load<Texture2D>("Component BG");
+    public static Texture ArrowR = Resources.Load<Texture>("Arrow_R");
+    public static Texture ArrowL = Resources.Load<Texture>("Arrow_L");
+    public static Texture Utils = Resources.Load<Texture>("Utils");
+    public static Texture Undo = Resources.Load<Texture>("Undo");
 
     public static GUIStyle CreatePreviewStyle(Texture2D bg) {
       return new GUIStyle(EditorStyles.helpBox) {
@@ -54,7 +54,7 @@ namespace UdonToolkit {
       });
       GUI.backgroundColor = Color.white;
     }
-    
+
     public static void RenderSectionHeader(ref Rect position, string name) {
       GUI.backgroundColor = new Color(0.5f , 0.5f, 0.5f);
       EditorGUI.LabelField(position, new GUIContent(name), new GUIStyle(EditorStyles.helpBox) {
@@ -74,7 +74,7 @@ namespace UdonToolkit {
         }
       });
     }
-    
+
     public static void RenderNote(ref Rect position, string text) {
       var textColor = EditorGUIUtility.isProSkin ? new Color(1f, 1f, 1f, 0.5f) : new Color(0f, 0f, 0f, 0.8f);
       EditorGUILayout.LabelField(text, new GUIStyle(EditorStyles.helpBox) {
@@ -120,7 +120,7 @@ namespace UdonToolkit {
       fontSize = 9,
       fixedHeight = 16
     };
-    
+
     // based on https://github.com/Xiexe/Xiexes-Unity-Shaders/blob/master/Editor/XSStyles.cs#L275
     public static bool FoldoutHeader(string text, bool value, ref bool showUtils) {
       var shown = value;
@@ -150,7 +150,7 @@ namespace UdonToolkit {
       }
       GUI.Box(utilsRect, Utils, new GUIStyle());
       GUI.backgroundColor = Color.white;
-      
+
       if (e.type == EventType.MouseDown) {
         if (utilsRect.Contains(e.mousePosition)) {
           showUtils = !showUtils;
@@ -174,7 +174,7 @@ namespace UdonToolkit {
       fixedWidth = 20,
       fixedHeight = 17
     };
-    
+
     public static readonly GUIStyle MiniArrowRight = new GUIStyle(EditorStyles.miniButtonRight) {
       margin = new RectOffset(0, 0, 3, 3),
       fixedWidth = 20,
@@ -191,7 +191,7 @@ namespace UdonToolkit {
       },
       active = new GUIStyleState {
         background = (Texture2D) Undo
-      }, 
+      },
     };
   }
 }

--- a/Internals/Editor/CameraSystemSetup.cs
+++ b/Internals/Editor/CameraSystemSetup.cs
@@ -63,7 +63,7 @@ namespace UdonToolkit {
       if (GUILayout.Button("Documentation", GUILayout.ExpandWidth(true))) {
         Application.OpenURL(WikiURL);
       }
-      
+
       UTStyles.RenderSectionHeader("Position and Style");
 
       var newCameraSpot = (Transform) EditorGUILayout.ObjectField("Camera Position", cameraSpot, typeof(Transform), true);
@@ -92,7 +92,7 @@ namespace UdonToolkit {
 
       UTStyles.RenderSectionHeader("PostProcessing and Collisions");
       UTStyles.RenderNote("Layers are very important to the overall setup. Make sure you follow the instructions below");
-      
+
       layers.Clear();
       for (int i = 0; i < 32; i++) {
         var layerName = LayerMask.LayerToName(i);
@@ -108,7 +108,7 @@ namespace UdonToolkit {
       }
 
       var layersArr = layers.ToArray();
-      
+
       if (emptyLayer != 0) {
         if (GUILayout.Button("Setup Layers")) {
           SetupLayers();
@@ -130,7 +130,7 @@ namespace UdonToolkit {
         GUI.backgroundColor = oldColor;
       }
       if (GUILayout.Button("Create Camera System", GUILayout.Height(30))) {
-        RunCameraSetup();  
+        RunCameraSetup();
       }
 
       if (GUILayout.Button("Add Guide Stand Only", GUILayout.Height(20))) {
@@ -159,13 +159,18 @@ namespace UdonToolkit {
 
       cameraPPLayer = emptyLayer;
     }
-    
-    private static readonly string SciFiStandPath = "Assets/UdonToolkit/Systems/Camera System/Camera Stand.prefab";
-    private static readonly string TikiStandPath = "Assets/UdonToolkit/Systems/Camera System/Camera Stand Tiki.prefab";
-    private static readonly string CameraSystemPath = "Assets/UdonToolkit/Systems/Camera System/UT Camera System.prefab";
-    private static readonly string DefaultPPProfilePath = "Assets/UdonToolkit/Systems/Camera System/Assets/Camera Lens PP.asset";
-    private static readonly string FocusFarPPProfilePath = "Assets/UdonToolkit/Systems/Camera System/Assets/Camera Lens PP Far.asset";
-    private static readonly string FocalNearPPProfilePath = "Assets/UdonToolkit/Systems/Camera System/Assets/Camera Lens PP Focal.asset";
+
+    private static string GetSystemAssetPath(string path)
+    {
+      return AssetDatabase.GetAssetPath(Resources.Load<Texture2D>("Component BG")).Replace("Internals/Resources/Component BG.png", $"Systems/{path}");
+    }
+
+    private static readonly string SciFiStandPath = GetSystemAssetPath("Camera System/Camera Stand.prefab");
+    private static readonly string TikiStandPath = GetSystemAssetPath("Camera System/Camera Stand Tiki.prefab");
+    private static readonly string CameraSystemPath = GetSystemAssetPath("Camera System/UT Camera System.prefab");
+    private static readonly string DefaultPPProfilePath = GetSystemAssetPath("Camera System/Assets/Camera Lens PP.asset");
+    private static readonly string FocusFarPPProfilePath = GetSystemAssetPath("Camera System/Assets/Camera Lens PP Far.asset");
+    private static readonly string FocalNearPPProfilePath = GetSystemAssetPath("Camera System/Assets/Camera Lens PP Focal.asset");
 
     private void RunCameraSetup() {
       setup = false;
@@ -177,7 +182,7 @@ namespace UdonToolkit {
       if (addGuide) {
         AddGuide();
       }
-      
+
       // spawn camera
       var cameraPrefab = AssetDatabase.LoadAssetAtPath(CameraSystemPath, typeof(GameObject));
       var instancedCamera = PrefabUtility.InstantiatePrefab(cameraPrefab) as GameObject;
@@ -191,7 +196,7 @@ namespace UdonToolkit {
         Undo.RecordObject(child.gameObject, "Adjusted Camera Lens PP Layers");
         child.gameObject.layer = cameraPPLayer;
       }
-      
+
       var cameraObject = instancedCameraRoot.Find("Camera Lens").gameObject;
       var cameraLens = cameraObject.transform.Find("Lens Camera").gameObject;
 
@@ -200,7 +205,7 @@ namespace UdonToolkit {
         var overlaySphere = instancedCameraRoot.Find("Camera Tracker").Find("Sphere");
         overlaySphere.GetComponent<MeshRenderer>().sharedMaterial.SetTexture("_WatermarkImage", watermark);
       }
-      
+
       // add PP stuff, we have to do it manually as having these scripts in a prefab causes build time erorrs
       // TODO: extract this into a function
       var cameraPPComp = cameraLens.AddComponent<PostProcessLayer>();
@@ -236,7 +241,7 @@ namespace UdonToolkit {
         Undo.RegisterCreatedObjectUndo(child.gameObject, "Spawn Camera Lens");
       }
       DestroyImmediate(instancedCamera);
-      
+
       // setup constraints
       var constraint = cameraObject.GetComponent<ParentConstraint>();
       Undo.RecordObject(constraint, "Adjust Constraint Settings");

--- a/Internals/Editor/CameraSystemSetup.cs
+++ b/Internals/Editor/CameraSystemSetup.cs
@@ -82,7 +82,7 @@ namespace UdonToolkit {
         var newGuideStyle = (GuideStyle) EditorGUILayout.EnumPopup("Guide Panel Style", guideStyle);
         if (newGuideStyle != guideStyle || standObj == null || standObjEditor == null) {
           var standPath = newGuideStyle == GuideStyle.Futuristic ? SciFiStandPath : TikiStandPath;
-          standObj = AssetDatabase.LoadAssetAtPath(standPath, typeof(object));
+          standObj = LoadSystemAssetAtPath(standPath, typeof(object));
           standObjEditor = UnityEditor.Editor.CreateEditor(standObj);
         }
         var r = GUILayoutUtility.GetRect(450, 150);
@@ -140,7 +140,7 @@ namespace UdonToolkit {
 
     private void AddGuide() {
       var standPath = guideStyle == GuideStyle.Futuristic ? SciFiStandPath : TikiStandPath;
-      var standPrefab = AssetDatabase.LoadAssetAtPath(standPath, typeof(GameObject));
+      var standPrefab = LoadSystemAssetAtPath(standPath, typeof(GameObject));
       var instancedStand = PrefabUtility.InstantiatePrefab(standPrefab) as GameObject;
       instancedStand.transform.position = cameraSpot.position + Vector3.down * 0.275f + cameraSpot.forward * -0.110f + cameraSpot.right * -0.043f;
       instancedStand.transform.rotation = cameraSpot.rotation;
@@ -160,17 +160,18 @@ namespace UdonToolkit {
       cameraPPLayer = emptyLayer;
     }
 
-    private static string GetSystemAssetPath(string path)
+    private static Object LoadSystemAssetAtPath(string path, Type type)
     {
-      return AssetDatabase.GetAssetPath(Resources.Load<Texture2D>("Component BG")).Replace("Internals/Resources/Component BG.png", $"Systems/{path}");
+      var assetPath = AssetDatabase.GetAssetPath(Resources.Load<Texture2D>("Component BG")).Replace("Internals/Resources/Component BG.png", $"Systems/{path}");
+      return AssetDatabase.LoadAssetAtPath(assetPath, type);
     }
 
-    private static readonly string SciFiStandPath = GetSystemAssetPath("Camera System/Camera Stand.prefab");
-    private static readonly string TikiStandPath = GetSystemAssetPath("Camera System/Camera Stand Tiki.prefab");
-    private static readonly string CameraSystemPath = GetSystemAssetPath("Camera System/UT Camera System.prefab");
-    private static readonly string DefaultPPProfilePath = GetSystemAssetPath("Camera System/Assets/Camera Lens PP.asset");
-    private static readonly string FocusFarPPProfilePath = GetSystemAssetPath("Camera System/Assets/Camera Lens PP Far.asset");
-    private static readonly string FocalNearPPProfilePath = GetSystemAssetPath("Camera System/Assets/Camera Lens PP Focal.asset");
+    private static readonly string SciFiStandPath = "Camera System/Camera Stand.prefab";
+    private static readonly string TikiStandPath = "Camera System/Camera Stand Tiki.prefab";
+    private static readonly string CameraSystemPath = "Camera System/UT Camera System.prefab";
+    private static readonly string DefaultPPProfilePath = "Camera System/Assets/Camera Lens PP.asset";
+    private static readonly string FocusFarPPProfilePath = "Camera System/Assets/Camera Lens PP Far.asset";
+    private static readonly string FocalNearPPProfilePath = "Camera System/Assets/Camera Lens PP Focal.asset";
 
     private void RunCameraSetup() {
       setup = false;
@@ -184,7 +185,7 @@ namespace UdonToolkit {
       }
 
       // spawn camera
-      var cameraPrefab = AssetDatabase.LoadAssetAtPath(CameraSystemPath, typeof(GameObject));
+      var cameraPrefab = LoadSystemAssetAtPath(CameraSystemPath, typeof(GameObject));
       var instancedCamera = PrefabUtility.InstantiatePrefab(cameraPrefab) as GameObject;
       PrefabUtility.UnpackPrefabInstance(instancedCamera, PrefabUnpackMode.Completely, InteractionMode.AutomatedAction);
 
@@ -221,17 +222,17 @@ namespace UdonToolkit {
       defaultPPVolume.isGlobal = true;
       defaultPPVolume.weight = 1;
       defaultPPVolume.sharedProfile =
-        (PostProcessProfile) AssetDatabase.LoadAssetAtPath(DefaultPPProfilePath, typeof(PostProcessProfile));
+        (PostProcessProfile) LoadSystemAssetAtPath(DefaultPPProfilePath, typeof(PostProcessProfile));
       focusFarPPVolume.isGlobal = true;
       focusFarPPVolume.weight = 0;
       focusFarPPVolume.priority = 1;
       focusFarPPVolume.sharedProfile =
-        (PostProcessProfile) AssetDatabase.LoadAssetAtPath(FocusFarPPProfilePath, typeof(PostProcessProfile));
+        (PostProcessProfile) LoadSystemAssetAtPath(FocusFarPPProfilePath, typeof(PostProcessProfile));
       focalNearPPVolume.isGlobal = true;
       focalNearPPVolume.weight = 0;
       focalNearPPVolume.priority = 1;
       focalNearPPVolume.sharedProfile =
-        (PostProcessProfile) AssetDatabase.LoadAssetAtPath(FocalNearPPProfilePath, typeof(PostProcessProfile));
+        (PostProcessProfile) LoadSystemAssetAtPath(FocalNearPPProfilePath, typeof(PostProcessProfile));
 
       // move to root
       var childCount = instancedCamera.transform.childCount;


### PR DESCRIPTION
I know that Unity's asset loading is not very smart. But I would be happier if I could move the directory. (e.g. git submodules)

If the file is in the `Resource`, Unity will find them by relative path. However, the Camera System isn't there. So I had to find the path from another resource. It's not a perfect solution though, because it will break if that resource is lost...