### PR TITLE
Add Udon Sharp Assembly Definition of U# 1.0 Beta

### DIFF
--- a/UdonToolkitRuntime.asset
+++ b/UdonToolkitRuntime.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5136146375e9a0a498a72a0091b40cc1, type: 3}
+  m_Name: UdonToolkitRuntime
+  m_EditorClassIdentifier: 
+  sourceAssembly: {fileID: 5897886265953266890, guid: 80a8b162ac804404bae7b5fdc3041428,
+    type: 3}

--- a/UdonToolkitRuntime.asset.meta
+++ b/UdonToolkitRuntime.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc5ab72ad9527214aac253c31840da17
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Since U# 1.0 (Now Beta 8), Udon Sharp Assembly Definition is required.
On U# 0.x, it will be `Missing Script`, but it will not cause any errors.
